### PR TITLE
Mousewheel property should not be set as true

### DIFF
--- a/config/flexslider.config.php
+++ b/config/flexslider.config.php
@@ -17,7 +17,7 @@ return array(
     //'directionNav'      => true,                //Boolean: Create navigation for previous/next navigation? (true/false)
     //'controlNav'        => true,                //Boolean: Create navigation for paging control of each clide? Note: Leave true for manualControls usage
     //'keyboardNav'       => true,                //Boolean: Allow slider navigating via keyboard left/right keys
-    'mousewheel'        => true,               //Boolean: Allow slider navigating via mousewheel
+    //'mousewheel'        => false,               //Boolean: Allow slider navigating via mousewheel
     //'prevText'          => "Previous",          //String: Set the text for the "previous" directionNav item
     //'nextText'          => "Next",              //String: Set the text for the "next" directionNav item
     //'pausePlay'         => false,               //Boolean: Create pause/play dynamic element


### PR DESCRIPTION
This property is not practical. When I scroll the page, my mouse arrives on the slider, and scroll the slider and not the page ... This property is as false by default in FlexSlider.
