### PR TITLE
Using JS append thanks to fieldset is now possible in image_fields

### DIFF
--- a/static/js/admin/insert_update.js
+++ b/static/js/admin/insert_update.js
@@ -105,7 +105,7 @@ define(
                     $field.show();
                     $field.nosOnShow();
                 }
-                $field.siblings('.field_enclosure').hide();
+                $field.siblings('.field_enclosure').not($field).hide();
                 set_field_padding();
             }
 


### PR DESCRIPTION
Using a renderer in image fields may lead to add some script tag. Without this commit, this will make "siblings" method retrieve current image fields and hide these.
