### PR TITLE
Allow to add link or script tags in image_fields

### DIFF
--- a/static/js/admin/insert_update.js
+++ b/static/js/admin/insert_update.js
@@ -29,8 +29,9 @@ define(
                     dataType: 'json',
                     success: function(json) {
                         var $slide = $(json.slide);
-                        $slide.nosFormUI();
                         $slides_container.append($slide);
+                        $slide = $slide.filter('.field_enclosure');//remove <link> or <script> tags
+                        $slide.nosFormUI();
 
                         // Open the media centre directly
                         setTimeout(function openMediaCentre() {


### PR DESCRIPTION
Using a renderer in image fields may lead to add some script or link tag. Without this commit, this will make "siblings" method retrieve current image fields and hide these.
