### PR TITLE
Pass enhancer params to views

### DIFF
--- a/classes/controller/slideshow.ctrl.php
+++ b/classes/controller/slideshow.ctrl.php
@@ -113,6 +113,7 @@ class Controller_Slideshow extends Controller_Front_Application
                 'slideshow' => $slideshow,
                 'format' => $format,
                 'config' => \Arr::get($format_config, 'config', array()),
+                'args' => $args,
             ), false);
         }
     }


### PR DESCRIPTION
Currently, it's impossible to pass custom parameters (like a duration) to the slideshow views.
This PR purpose is to improve that by passing the enhancer configuration to the view.